### PR TITLE
Audit-logitus atarusta yhteiseen käyttöön

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,8 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+- provider: script
+  script: lein modules :dirs "clj-timbre-auditlog" do deploy
+  skip_cleanup: true
+  on:
+    branch: audit-logitus_atarusta

--- a/clj-log/project.clj
+++ b/clj-log/project.clj
@@ -1,10 +1,10 @@
-(defproject oph/clj-log "0.2.4-SNAPSHOT"
+(defproject oph/clj-log "0.3.0-SNAPSHOT"
             :description "oph clojure logging utilities"
             :url "http://example.com/FIXME"
             :license {:name "EUPL"
                       :url "http://www.osor.eu/eupl/"}
             :plugins [[lein-modules "0.3.11"]]
-            :dependencies [[org.clojure/tools.logging "0.4.0"]
-                           [clj-time "0.14.2"]
-                           [cheshire "5.8.0"]
+            :dependencies [[org.clojure/tools.logging "1.0.0"]
+                           [clj-time "0.15.2"]
+                           [cheshire "5.10.0"]
                            [slingshot "0.12.2"]])

--- a/clj-timbre-auditlog/LICENSE.txt
+++ b/clj-timbre-auditlog/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright (c) 2020 Finnish National Agency for Education - Opetushallitus
+
+This program is free software:  Licensed under the EUPL, Version 1.1 or - as
+soon as they will be approved by the European Commission - subsequent versions
+of the EUPL (the "Licence");
+
+You may not use this work except in compliance with the Licence.
+You may obtain a copy of the Licence at: http://www.osor.eu/eupl/
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+European Union Public Licence for more details.

--- a/clj-timbre-auditlog/README.md
+++ b/clj-timbre-auditlog/README.md
@@ -1,0 +1,8 @@
+# clj-timbre-auditlog
+
+Kääre, jolla saa [auditlogger](https://github.com/Opetushallitus/auditlogger) -logituksen
+ohjattua Clojuren logikirjasto Timbrelle.
+
+## License
+
+See [LICENSE.txt](LICENSE.txt)

--- a/clj-timbre-auditlog/project.clj
+++ b/clj-timbre-auditlog/project.clj
@@ -1,0 +1,18 @@
+(defproject oph/clj-timbre-auditlog "0.1.0-SNAPSHOT"
+  :description "Clojure-kirjasto Opintopolun audit-login teekemiseksi Clojure-palveluista"
+  :url "http://example.com/FIXME"
+  :license {:name "EUPL, Version 1.1 or - as soon as they will be approved by the European Commission - subsequent versions of the EUPL (the \"Licence\")"
+            :url "http://www.osor.eu/eupl/"}
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [com.taoensso/timbre "4.10.0"]
+                 [cheshire/cheshire "5.10.0"]
+                 [fi.vm.sade/auditlogger "8.3.0-SNAPSHOT"]
+                 [environ "1.1.0"]]
+  :repl-options {:init-ns clj-timbre-auditlog.core}
+
+  :plugins [[lein-modules "0.3.11"]
+            [lein-ancient "0.6.15"]
+            [lein-less "1.7.5"]
+            [lein-shell "0.5.0"]]
+
+  :min-lein-version "2.5.3")

--- a/clj-timbre-auditlog/src/clj_timbre_auditlog/audit_log.clj
+++ b/clj-timbre-auditlog/src/clj_timbre_auditlog/audit_log.clj
@@ -1,0 +1,34 @@
+(ns clj-timbre-auditlog.audit-log
+    (:require [cheshire.core :as json]
+              [taoensso.timbre :as timbre]
+              [environ.core :refer [env]]
+              [clojure.data :refer [diff]]
+              [taoensso.timbre.appenders.core :refer [println-appender]]
+              [taoensso.timbre.appenders.3rd-party.rolling :refer [rolling-appender]])
+    (:import [fi.vm.sade.auditlog
+              Logger
+              Audit
+              ApplicationType]
+             java.util.TimeZone))
+
+(defn create-audit-logger [service-name base-path ^ApplicationType application-type]
+  (let [audit-log-config (assoc timbre/example-config
+                                :appenders {:file-appender   (assoc (rolling-appender
+                                                                     {:path    (str base-path
+                                                                                    "/audit_" service-name
+                                                                                    ;; Hostname will differentiate files in actual environments
+                                                                                    (when (:hostname env) (str "_" (:hostname env))))
+                                                                      :pattern :daily})
+                                                                    :output-fn (fn [data] (force (:msg_ data))))
+                                            :stdout-appender (assoc (println-appender
+                                                                     {:stream :std-out})
+                                                                    :output-fn (fn [data]
+                                                                                 (json/generate-string
+                                                                                  {:eventType "audit"
+                                                                                   :timestamp (force (:timestamp_ data))
+                                                                                   :event     (json/parse-string (force (:msg_ data)))})))}
+                                :timestamp-opts {:pattern  "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+                                                 :timezone (TimeZone/getTimeZone "Europe/Helsinki")})
+        logger           (proxy [Logger] [] (log [s]
+                                              (timbre/log* audit-log-config :info s)))]
+    (new Audit logger service-name application-type)))

--- a/clj-timbre-auditlog/test/clj_timbre_auditlog/audit_log_test.clj
+++ b/clj-timbre-auditlog/test/clj_timbre_auditlog/audit_log_test.clj
@@ -1,0 +1,9 @@
+(ns clj-timbre-auditlog.audit-log-test
+  (:require [clojure.test :refer :all]
+            [clj-timbre-auditlog.audit-log :as audit-log])
+  (:import (fi.vm.sade.auditlog ApplicationType Audit)))
+
+(deftest audit-log-can-be-created
+  (testing "Audit log creation"
+    (let [^Audit audit-logger (audit-log/create-audit-logger "clj-log" "/tmp" ApplicationType/BACKEND)]
+      (.logHeartbeat audit-logger))))


### PR DESCRIPTION
* Atarun Audit-olion initialisointi Timbreä käyttämään ja Timbre-konfigurointi tänne
* clj-log-kirjaston riippuvuuksien päivittäminen