### PR TITLE
docker-test-fixture

### DIFF
--- a/clj-test-utils/project.clj
+++ b/clj-test-utils/project.clj
@@ -1,4 +1,4 @@
-(defproject oph/clj-test-utils "0.2.7-SNAPSHOT"
+(defproject oph/clj-test-utils "0.2.8-SNAPSHOT"
             :description "oph clojure testing utilities"
             :url "http://example.com/FIXME"
             :license {:name "EUPL"

--- a/clj-test-utils/src/clj_test_utils/elasticsearch_mock_utils.clj
+++ b/clj-test-utils/src/clj_test_utils/elasticsearch_mock_utils.clj
@@ -1,7 +1,8 @@
 (ns clj-test-utils.elasticsearch-mock-utils
     (:require
       [clj-test-utils.port-finder :refer [find-free-local-port]]
-      [robert.hooke :refer [add-hook]])
+      [robert.hooke :refer [add-hook]]
+      [clojure.java.shell :refer [sh]])
   (:import
     (pl.allegro.tech.embeddedelasticsearch EmbeddedElastic PopularProperties)
     (java.util.concurrent TimeUnit)))
@@ -46,3 +47,29 @@
           (when embedded-elasticsearch? (stop-elastic-test))
           result)))
     (add-hook #'clojure.test/run-tests #'run-all-test-hook))
+
+(defn stop-docker-elastic []
+  (sh "docker" "kill" "kouta-elastic"))
+
+(defn init-docker-elastic []
+  (let [port (find-free-local-port)
+        elastic-ip (str "http://127.0.0.1:" port)
+        elastic-docker-ip (str "127.0.0.1:" port ":9200")]
+    (intern 'clj-elasticsearch.elastic-utils 'elastic-host elastic-ip)
+    ;(println (sh "curl" (str elastic-ip "/_cluster/health")))
+    (println (sh "docker" "run" "--rm" "-d" "--name" "kouta-elastic" "--env" "\"discovery.type=single-node\"" "-p" elastic-docker-ip "docker.elastic.co/elasticsearch/elasticsearch:6.8.13"))
+    (println "Starting elasticsearch container")
+    (Thread/sleep 16000) ;TODO toteuta pollaus milloin elastic on käynnistynyt
+    ;(println (sh "curl" (str elastic-ip "/_cluster/health")))
+    ))
+
+(defn global-docker-elastic-fixture
+  []
+  (defn- run-tests-hook
+    [f & nss]
+    (let [embedded-elasticsearch? (find-ns 'clj-elasticsearch.elastic-utils)]
+      (when embedded-elasticsearch? (init-docker-elastic))
+      (let [result (apply f nss)]
+        (when embedded-elasticsearch? (stop-docker-elastic))
+        result)))
+  (add-hook #'clojure.test/run-tests #'run-tests-hook))


### PR DESCRIPTION
Lisätty fixture jolla elasticsearchia käyttävät testit voi ajaa elasticsearch konttia vasten. Toteutus vielä hieman kesken, jatkuu toisella pr:llä.